### PR TITLE
Bump rapidfuzz version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir=
 packages = find:
 python_requires = >=3.5
 install_requires =
-    rapidfuzz >= 1.8.2, < 1.9
+    rapidfuzz >= 1.8.2, < 2.0
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
Jump from currently supported rapidfuzz version and 1.9.x introduced no breaking changes (and it makes my pip angry)