### PR TITLE
Remove redundant `wheel` dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
     "scikit-build>=0.13.0",
     "cmake",
     "ninja; platform_system!='Windows'",


### PR DESCRIPTION
Remove the redundant `wheel` dependency from pyproject.toml.  All
setuptools version automatically expose the dependency via the PEP517
backend since day one.  Listing it explicitly in build requirements
was a documentation mistake that was fixed in:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a